### PR TITLE
Fix: Initial page load visual glitches

### DIFF
--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -40,7 +40,7 @@ const contentScrollVariants = {
 export default function Home() {
   return (
     <div className="bg-teal pb-4">
-      <div className="min-w-screen bg-sand">
+      <div className="min-w-screen min-h-screen bg-sand">
         <div className="flex flex-row flex-wrap justify-center items-center gap-12 pt-16 px-4 bg-sand">
           <motion.div
             initial={{ x: -150, opacity: 0 }}
@@ -65,8 +65,8 @@ export default function Home() {
           </motion.div>
         </div>
         <motion.div
-          initial={{ y: 200, opacity: 0 }}
-          animate={{ y: 0, opacity: 1 }}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
           transition={{ delay: 0.1, duration: 0.7, ease: "easeInOut" }}
         >
           <Image

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -64,9 +64,10 @@ export default function Home() {
             />
           </motion.div>
         </div>
+        <div className="overflow-hidden">
         <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
+          initial={{ y: 200, opacity: 0 }}
+          animate={{ y: 0, opacity: 1 }}
           transition={{ delay: 0.1, duration: 0.7, ease: "easeInOut" }}
         >
           <Image
@@ -79,6 +80,7 @@ export default function Home() {
             alt="Beach"
           />
         </motion.div>
+        </div>
       </div>
       <div className="flex flex-col items-center max-w-screen-lg px-4 mx-auto">
         <div className="flex justify-center flex-wrap gap-12 mb-12">


### PR DESCRIPTION
## Summary
- Fixed teal background bleeding through on initial load by adding `min-h-screen` to the sand container
- Restored the beach wave wash-up animation by wrapping it in an `overflow-hidden` container, preventing teal/content from flashing in during the slide-up

## Test plan
- [x] Verify no teal background visible on initial page load
- [x] Verify beach wave animates upward cleanly on load

